### PR TITLE
Addresses #38 by not allowing any "falsy" type for resolve

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,27 +32,17 @@ When making changes to the TypeScript interfaces, run `yarn test` to ensure ther
 
 ### Type aliases
 
-* [ActionMap](#actionmap)
 * [Context](#context)
 
 ---
 
 ## Type aliases
 
-<a id="actionmap"></a>
-
-###  ActionMap
-
-**Ƭ ActionMap**: *[ActionMetadata](interfaces/actionmetadata.md)[]*
-
-*Defined in [interface.ts:16](/src/interface.ts#L16)*
-
-___
 <a id="context"></a>
 
 ###  Context
 
-**Ƭ Context**: *`Object`*
+**Ƭ Context**: *`any`*
 
 *Defined in [interface.ts:1](/src/interface.ts#L1)*
 

--- a/docs/interfaces/actionmetadata.md
+++ b/docs/interfaces/actionmetadata.md
@@ -25,7 +25,7 @@ Provides a mapping of Apps to Intents
 
 **● apps**: *[AppMetadata](appmetadata.md)[]*
 
-*Defined in [interface.ts:31](/src/interface.ts#L31)*
+*Defined in [interface.ts:29](/src/interface.ts#L29)*
 
 ___
 <a id="intent"></a>
@@ -34,7 +34,7 @@ ___
 
 **● intent**: *[IntentMetadata](intentmetadata.md)*
 
-*Defined in [interface.ts:30](/src/interface.ts#L30)*
+*Defined in [interface.ts:28](/src/interface.ts#L28)*
 
 ___
 

--- a/docs/interfaces/appmetadata.md
+++ b/docs/interfaces/appmetadata.md
@@ -22,9 +22,9 @@ App metadata is Desktop Agent specific - but should support a name property.
 
 ###  name
 
-**● name**: *`String`*
+**● name**: *`string`*
 
-*Defined in [interface.ts:39](/src/interface.ts#L39)*
+*Defined in [interface.ts:36](/src/interface.ts#L36)*
 
 ___
 

--- a/docs/interfaces/desktopagent.md
+++ b/docs/interfaces/desktopagent.md
@@ -31,7 +31,7 @@ A Desktop Agent can be connected to one or more App Directories and will use dir
 
 ▸ **broadcast**(context: *[Context](../#context)*): `void`
 
-*Defined in [interface.ts:128](/src/interface.ts#L128)*
+*Defined in [interface.ts:125](/src/interface.ts#L125)*
 
 Publishes context to other apps on the desktop.
 
@@ -54,7 +54,7 @@ ___
 
 ▸ **contextListener**(handler: *`function`*): [Listener](listener.md)
 
-*Defined in [interface.ts:149](/src/interface.ts#L149)*
+*Defined in [interface.ts:146](/src/interface.ts#L146)*
 
 Listens to incoming context broadcast from the Desktop Agent.
 
@@ -71,9 +71,9 @@ ___
 
 ###  intentListener
 
-▸ **intentListener**(intent: *`String`*, handler: *`function`*): [Listener](listener.md)
+▸ **intentListener**(intent: *`string`*, handler: *`function`*): [Listener](listener.md)
 
-*Defined in [interface.ts:144](/src/interface.ts#L144)*
+*Defined in [interface.ts:141](/src/interface.ts#L141)*
 
 Listens to incoming Intents from the Agent.
 
@@ -81,7 +81,7 @@ Listens to incoming Intents from the Agent.
 
 | Param | Type |
 | ------ | ------ |
-| intent | `String` |
+| intent | `string` |
 | handler | `function` |
 
 **Returns:** [Listener](listener.md)
@@ -91,9 +91,9 @@ ___
 
 ###  open
 
-▸ **open**(name: *`String`*, context?: *[Context](../#context)*): `Promise`<`void`>
+▸ **open**(name: *`string`*, context?: *[Context](../#context)*): `Promise`<`void`>
 
-*Defined in [interface.ts:90](/src/interface.ts#L90)*
+*Defined in [interface.ts:87](/src/interface.ts#L87)*
 
 Launches/links to an app by name.
 
@@ -112,7 +112,7 @@ If opening errors, it returns an `Error` with a string from the `OpenError` enum
 
 | Param | Type |
 | ------ | ------ |
-| name | `String` |
+| name | `string` |
 | `Optional` context | [Context](../#context) |
 
 **Returns:** `Promise`<`void`>
@@ -122,9 +122,9 @@ ___
 
 ###  raiseIntent
 
-▸ **raiseIntent**(intent: *`String`*, context: *[Context](../#context)*, target?: *`String`*): `Promise`<[IntentResolution](intentresolution.md)>
+▸ **raiseIntent**(intent: *`string`*, context: *[Context](../#context)*, target?: *`string`*): `Promise`<[IntentResolution](intentresolution.md)>
 
-*Defined in [interface.ts:139](/src/interface.ts#L139)*
+*Defined in [interface.ts:136](/src/interface.ts#L136)*
 
 Raises an intent to the desktop agent to resolve.
 
@@ -139,9 +139,9 @@ agent.raiseIntent("StartChat", newContext, intentR.source);
 
 | Param | Type |
 | ------ | ------ |
-| intent | `String` |
+| intent | `string` |
 | context | [Context](../#context) |
-| `Optional` target | `String` |
+| `Optional` target | `string` |
 
 **Returns:** `Promise`<[IntentResolution](intentresolution.md)>
 
@@ -150,13 +150,13 @@ ___
 
 ###  resolve
 
-▸ **resolve**(intent: *`String`*, context?: *[Context](../#context)*): `Promise`<`Array`<[ActionMetadata](actionmetadata.md)>>
+▸ **resolve**(intent: * `string` &#124; `undefined`*, context?: *[Context](../#context)*): `Promise`<[ActionMetadata](actionmetadata.md)[]>
 
-*Defined in [interface.ts:120](/src/interface.ts#L120)*
+*Defined in [interface.ts:117](/src/interface.ts#L117)*
 
 Resolves an intent & context pair to a mapping of Intents and Apps (action metadata).
 
-Resolve is effectively granting programmatic access to the Desktop Agent's resolver. Returns a promise that resolves to an Array. The resolved dataset & metadata is Desktop Agent-specific. If intent argument is falsey, then all possible intents - and apps corresponding to the intents - are resolved for the provided context. If the resolution errors, it returns an `Error` with a string from the `ResolveError` enumeration.
+Resolve is effectively granting programmatic access to the Desktop Agent's resolver. Returns a promise that resolves to an Array. The resolved dataset & metadata is Desktop Agent-specific. If the intent argument is undefined, then all possible intents - and apps corresponding to the intents - are resolved for the provided context. If the resolution errors, it returns an `Error` with a string from the `ResolveError` enumeration.
 
 ```javascript
 // find what intents and apps are supported for a given context
@@ -182,10 +182,10 @@ await agent.raiseIntent(selectedAction.intent.name, context, selectedApp.name);
 
 | Param | Type |
 | ------ | ------ |
-| intent | `String` |
+| intent |  `string` &#124; `undefined`|
 | `Optional` context | [Context](../#context) |
 
-**Returns:** `Promise`<`Array`<[ActionMetadata](actionmetadata.md)>>
+**Returns:** `Promise`<[ActionMetadata](actionmetadata.md)[]>
 
 ___
 

--- a/docs/interfaces/intentmetadata.md
+++ b/docs/interfaces/intentmetadata.md
@@ -23,18 +23,18 @@ Intent descriptor
 
 ###  displayName
 
-**● displayName**: *`String`*
+**● displayName**: *`string`*
 
-*Defined in [interface.ts:23](/src/interface.ts#L23)*
+*Defined in [interface.ts:21](/src/interface.ts#L21)*
 
 ___
 <a id="name"></a>
 
 ###  name
 
-**● name**: *`String`*
+**● name**: *`string`*
 
-*Defined in [interface.ts:22](/src/interface.ts#L22)*
+*Defined in [interface.ts:20](/src/interface.ts#L20)*
 
 ___
 

--- a/docs/interfaces/intentresolution.md
+++ b/docs/interfaces/intentresolution.md
@@ -32,27 +32,27 @@ var dataR = intentR.data;
 
 ### `<Optional>` data
 
-**● data**: *`Object`*
+**● data**: *`object`*
 
-*Defined in [interface.ts:54](/src/interface.ts#L54)*
+*Defined in [interface.ts:51](/src/interface.ts#L51)*
 
 ___
 <a id="source"></a>
 
 ###  source
 
-**● source**: *`String`*
+**● source**: *`string`*
 
-*Defined in [interface.ts:53](/src/interface.ts#L53)*
+*Defined in [interface.ts:50](/src/interface.ts#L50)*
 
 ___
 <a id="version"></a>
 
 ###  version
 
-**● version**: *`String`*
+**● version**: *`string`*
 
-*Defined in [interface.ts:55](/src/interface.ts#L55)*
+*Defined in [interface.ts:52](/src/interface.ts#L52)*
 
 ___
 

--- a/docs/interfaces/listener.md
+++ b/docs/interfaces/listener.md
@@ -22,7 +22,7 @@
 
 ▸ **unsubscribe**(): `any`
 
-*Defined in [interface.ts:62](/src/interface.ts#L62)*
+*Defined in [interface.ts:59](/src/interface.ts#L59)*
 
 Unsubscribe the listener object.
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,4 +1,4 @@
-type Context = Object;
+type Context = object;
 
 enum OpenError {
   AppNotFound = "AppNotFound",
@@ -13,30 +13,27 @@ enum ResolveError {
   ResolverTimeout = "ResolverTimeout"
 }
 
-type ActionMap = ActionMetadata[]
-
  /**
  * Intent descriptor
  */ 
 interface IntentMetadata {
-  name:String;
-  displayName:String;
+  name: string;
+  displayName: string;
 }
 
  /**
  * Provides a mapping of Apps to Intents
  */ 
 interface ActionMetadata {
-  intent:IntentMetadata;
-  apps:AppMetadata[];
+  intent: IntentMetadata;
+  apps: AppMetadata[];
 }
-
 
 /**
  * App metadata is Desktop Agent specific - but should support a name property.
  */
 interface AppMetadata {
-  name: String;
+  name: string;
 }
 
 /**
@@ -50,9 +47,9 @@ interface AppMetadata {
  * ```
  */
 interface IntentResolution {
-  source: String;
-  data?: Object; 
-  version: String;
+  source: string;
+  data?: object; 
+  version: string;
 }
 
 interface Listener {
@@ -87,14 +84,14 @@ interface DesktopAgent {
    *     agent.open('myApp', context);
    * ```
    */
-  open(name: String, context?: Context): Promise<void>;
+  open(name: string, context?: Context): Promise<void>;
 
   /**
    * Resolves an intent & context pair to a mapping of Intents and Apps (action metadata).
    *
    * Resolve is effectively granting programmatic access to the Desktop Agent's resolver. 
    * Returns a promise that resolves to an Array. The resolved dataset & metadata is Desktop Agent-specific.
-   * If intent argument is falsey, then all possible intents - and apps corresponding to the intents - are resolved for the provided context.
+   * If the intent argument is undefined, then all possible intents - and apps corresponding to the intents - are resolved for the provided context.
    * If the resolution errors, it returns an `Error` with a string from the `ResolveError` enumeration.
    * 
    * ```javascript
@@ -117,7 +114,7 @@ interface DesktopAgent {
    * await agent.raiseIntent(selectedAction.intent.name, context, selectedApp.name);
    * ```
    */
-  resolve(intent: String, context?: Context): Promise<Array<ActionMetadata>>;
+  resolve(intent: string | undefined, context?: Context): Promise<ActionMetadata[]>;
 
   /**
    * Publishes context to other apps on the desktop.
@@ -136,12 +133,12 @@ interface DesktopAgent {
    * agent.raiseIntent("StartChat", newContext, intentR.source);
    * ```
    */
-  raiseIntent(intent: String, context: Context, target?: String): Promise<IntentResolution>;
+  raiseIntent(intent: string, context: Context, target?: string): Promise<IntentResolution>;
 
   /**
    * Listens to incoming Intents from the Agent.
    */
-  intentListener(intent: String, handler: (context: Context) => void): Listener;
+  intentListener(intent: string, handler: (context: Context) => void): Listener;
 
   /**
    * Listens to incoming context broadcast from the Desktop Agent.


### PR DESCRIPTION
Parameter type is `string | undefined`.

Also: 
- `string` instead of `String`
- `object` instead of `Object`
- `[]` instead of `Array<T>`
- Remove unused `ActionMap`